### PR TITLE
[SOI-266] Adding Sidekiq Pro token as a docker build arg

### DIFF
--- a/rocksteady
+++ b/rocksteady
@@ -172,7 +172,7 @@ sub_build() {
 
   `AWS_ACCESS_KEY_ID=$aws_access_key_id AWS_SECRET_ACCESS_KEY=$aws_secret_access_key aws ecr get-login --no-include-email --region $aws_region`
 
-  docker build `printf " -t %s" "${tags[@]}"` .
+  docker build `printf " -t %s" "${tags[@]}"` --build-arg BUNDLE_GEMS__CONTRIBSYS__COM="${SIDEKIQ_PRO_TOKEN}" .
   for tag in "${tags[@]}"
   do
     docker push $tag


### PR DESCRIPTION
### Why?

Recently we acquired Sidekiq Pro licence which needs to injected at build time of Docker images, otherwise installing the bundle step will fail. The changed command won't affect images that do not need this build argument in any way.

### What changed?

* Added a build arg with the Sidekiq Pro token ENV variable from CircleCI to the `docker build` command 