### PR TITLE
Support passing gemfury token to docker build

### DIFF
--- a/rocksteady
+++ b/rocksteady
@@ -47,6 +47,12 @@ usage()
   echo "  \$CIRCLE_SHA1"
   echo "    Specify the commit SHA for use in tagging"
   echo
+  echo "  \$BUNDLE_GEM__FURY__IO"
+  echo "    Specify the token for accessing the Altmetric private gem repository (Optional)"
+  echo
+  echo "  \$SIDEKIQ_PRO_TOKEN"
+  echo "    Specify the token for installing Sidekiq Pro gem (Optional)"
+  echo
   echo "Exit codes:"
   echo "  0 - Success"
   echo "  1 - General failure"
@@ -172,7 +178,7 @@ sub_build() {
 
   `AWS_ACCESS_KEY_ID=$aws_access_key_id AWS_SECRET_ACCESS_KEY=$aws_secret_access_key aws ecr get-login --no-include-email --region $aws_region`
 
-  docker build `printf " -t %s" "${tags[@]}"` --build-arg SIDEKIQ_PRO_TOKEN=$SIDEKIQ_PRO_TOKEN .
+  docker build `printf " -t %s" "${tags[@]}"` --build-arg SIDEKIQ_PRO_TOKEN=$SIDEKIQ_PRO_TOKEN --build-arg BUNDLE_GEM__FURY__IO=$BUNDLE_GEM__FURY__IO .
   for tag in "${tags[@]}"
   do
     docker push $tag


### PR DESCRIPTION
## Why?

Currently, credentials for the private gem repository used by altmetric are visible in Gemfile. As this represents a security risk, we want to move them to the environment.

## What?

Pass the value of the gemfury token as an argument, to be used by the Dockerfile.