### PR TITLE
Pass in GitHub token for central DSUI repo components from CI environment

### DIFF
--- a/rocksteady
+++ b/rocksteady
@@ -172,7 +172,7 @@ sub_build() {
 
   `AWS_ACCESS_KEY_ID=$aws_access_key_id AWS_SECRET_ACCESS_KEY=$aws_secret_access_key aws ecr get-login --no-include-email --region $aws_region`
 
-  docker build `printf " -t %s" "${tags[@]}"` --build-arg SIDEKIQ_PRO_TOKEN=$SIDEKIQ_PRO_TOKEN .
+  docker build `printf " -t %s" "${tags[@]}"` --build-arg SIDEKIQ_PRO_TOKEN=$SIDEKIQ_PRO_TOKEN --build-arg DSUI_GITHUB_TOKEN=$DSUI_GITHUB_TOKEN .
   for tag in "${tags[@]}"
   do
     docker push $tag


### PR DESCRIPTION
In order to import new libraries from [the central DSUI repository](https://github.com/digital-science/central-dsui), Altmetric applications need access to a GitHub token that allows them to install these libraries ready for deployment.  In order to achieve this, the token will be stored as an environment variable in CircleCI for the relevant projects.  The change here allows this env var to be used when building the Docker image for deployment to rocksteady following the same pattern that is used for the `SIDEKIQ_PRO_TOKEN`.